### PR TITLE
Refactor credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
-- Keeping `password`, `token`, and `private_key` as `SecretStr` in `block_initialization` so logging doesn't show secrets - [#22](https://github.com/PrefectHQ/prefect-snowflake/pull/22)
+- Swap out `block_initialization` for `_get_connect_params` so logging the block doesn't show secrets - [#24](https://github.com/PrefectHQ/prefect-snowflake/pull/24)
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 
 ### Removed
+- Removed the keywords, `database` and `warehouse`, from `snowflake_query` and `snowflake_multiquery` - [#24](https://github.com/PrefectHQ/prefect-snowflake/pull/24)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `SnowflakeConnector` block - [#24](https://github.com/PrefectHQ/prefect-snowflake/pull/24)
 
 ### Changed
-- Moved the keywords, `database` and `warehouse`, from `SnowflakeCredentials` into `SnowflakeConnector` - [#24](https://github.com/PrefectHQ/prefect-snowflake/pull/24)
-- Moved the method `get_connection` from `SnowflakeCredentials` into `SnowflakeConnector` - [#24](https://github.com/PrefectHQ/prefect-snowflake/pull/24)
+- Moved the keywords, `database` and `warehouse`, from `credentials.SnowflakeCredentials` into `database.SnowflakeConnector` - [#24](https://github.com/PrefectHQ/prefect-snowflake/pull/24)
+- Moved the method `get_connection` from `credentials.SnowflakeCredentials` into `database.SnowflakeConnector` - [#24](https://github.com/PrefectHQ/prefect-snowflake/pull/24)
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,17 +8,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Added
+- `SnowflakeConnector` block - [#24](https://github.com/PrefectHQ/prefect-snowflake/pull/24)
 
 ### Changed
+- Moved the keywords, `database` and `warehouse`, from `SnowflakeCredentials` into `SnowflakeConnector` - [#24](https://github.com/PrefectHQ/prefect-snowflake/pull/24)
+- Moved the method `get_connection` from `SnowflakeCredentials` into `SnowflakeConnector` - [#24](https://github.com/PrefectHQ/prefect-snowflake/pull/24)
 
 ### Deprecated
 
 ### Removed
 
 ### Fixed
-- Swap out `block_initialization` for `_get_connect_params` so logging the block doesn't show secrets - [#24](https://github.com/PrefectHQ/prefect-snowflake/pull/24)
 
 ### Security
+- Fixed hiding the input password under `connect_params` when logging `SnowflakeCredentials` - [#24](https://github.com/PrefectHQ/prefect-snowflake/pull/24)
+
+## 0.2.0
+Released on August ??th, 2022.
 
 ## 0.1.3
 Released on July 26th, 2022.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 ### Security
-- Fixed hiding the input password under `connect_params` when logging `SnowflakeCredentials` - [#24](https://github.com/PrefectHQ/prefect-snowflake/pull/24)
+- Fixed revealing the input password nested under `connect_params` when logging `SnowflakeCredentials` - [#24](https://github.com/PrefectHQ/prefect-snowflake/pull/24)
 
 ## 0.2.0
 Released on August ??th, 2022.

--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ pip install prefect-snowflake
 
 ```python
 from prefect import flow
-from prefect_snowflake import SnowflakeCredentials
-from prefect_snowflake.database import snowflake_query
+from prefect_snowflake.credentials import SnowflakeCredentials
+from prefect_snowflake.database import SnowflakeConnector, snowflake_query
 
 
 @flow
@@ -37,9 +37,15 @@ def snowflake_query_flow():
         user="user",
         password="password",
     )
+    snowflake_connector = SnowflakeConnector(
+        database="database",
+        warehouse="warehouse",
+        schema="schema",
+        credentials=snowflake_credentials
+    )
     result = snowflake_query(
         "SELECT * FROM table WHERE id=%{id_param}s LIMIT 8;",
-        snowflake_credentials,
+        snowflake_connector,
         params={"id_param": 1}
     )
     return result

--- a/prefect_snowflake/__init__.py
+++ b/prefect_snowflake/__init__.py
@@ -1,7 +1,6 @@
 from . import _version
 from prefect_snowflake.credentials import (  # noqa
     SnowflakeCredentials,
-    SnowflakeConnector,
 )
 
 __version__ = _version.get_versions()["version"]

--- a/prefect_snowflake/__init__.py
+++ b/prefect_snowflake/__init__.py
@@ -1,4 +1,7 @@
 from . import _version
-from prefect_snowflake.credentials import SnowflakeCredentials  # noqa
+from prefect_snowflake.credentials import (  # noqa
+    SnowflakeCredentials,
+    SnowflakeConnector,
+)
 
 __version__ = _version.get_versions()["version"]

--- a/prefect_snowflake/credentials.py
+++ b/prefect_snowflake/credentials.py
@@ -130,11 +130,9 @@ class SnowflakeCredentials(Block):
                     f"The {param} must be set in either "
                     f"SnowflakeCredentials or the task"
                 )
-        connect_params = {
-            key: val.get_secret_value()
-            if isinstance(val, (SecretBytes, SecretStr))
-            else val
-            for key, val in connect_params.items()
-        }
+        for param in ("password", "private_key", "token"):
+            if param in connect_params:
+                connect_params[param] = connect_params[param].get_secret_value()
+
         connection = connector.connect(**connect_params)
         return connection

--- a/prefect_snowflake/credentials.py
+++ b/prefect_snowflake/credentials.py
@@ -1,10 +1,9 @@
 """Credentials class to authenticate Snowflake."""
 
-from typing import Dict, Optional
+from typing import Optional
 
 from prefect.blocks.core import Block
 from pydantic import Field, SecretBytes, SecretStr, root_validator
-from snowflake import connector
 
 
 class SnowflakeCredentials(Block):
@@ -12,19 +11,19 @@ class SnowflakeCredentials(Block):
     Block used to manage authentication with Snowflake.
 
     Args:
-        account: The snowflake account name.
-        user: The user name used to authenticate.
-        password: The password used to authenticate.
-        private_key: The PEM used to authenticate.
-        authenticator: The type of authenticator to use for initializing
+        account (str): The snowflake account name.
+        user (str): The user name used to authenticate.
+        password (SecretStr): The password used to authenticate.
+        private_key (SecretStr): The PEM used to authenticate.
+        authenticator (str): The type of authenticator to use for initializing
             connection (oauth, externalbrowser, etc); refer to
             [Snowflake documentation](https://docs.snowflake.com/en/user-guide/python-connector-api.html#connect)
             for details, and note that `externalbrowser` will only
             work in an environment where a browser is available.
-        token: The OAuth or JWT Token to provide when
+        token (SecretStr): The OAuth or JWT Token to provide when
             authenticator is set to OAuth.
-        role: The name of the default role to use.
-        autocommit: Whether to automatically commit.
+        role (str): The name of the default role to use.
+        autocommit (bool): Whether to automatically commit.
 
     Example:
         Load stored Snowflake credentials:
@@ -37,14 +36,33 @@ class SnowflakeCredentials(Block):
     _block_type_name = "Snowflake Credentials"
     _logo_url = "https://images.ctfassets.net/gm98wzqotmnx/2DxzAeTM9eHLDcRQx1FR34/f858a501cdff918d398b39365ec2150f/snowflake.png?h=250"  # noqa
 
-    account: str
-    user: str
-    password: Optional[SecretStr] = None
-    private_key: Optional[SecretBytes] = None
-    authenticator: Optional[str] = None
-    token: Optional[SecretStr] = None
-    role: Optional[str] = None
-    autocommit: Optional[bool] = None
+    account: str = Field(..., description="The snowflake account name")
+    user: str = Field(..., description="The user name used to authenticate")
+    password: Optional[SecretStr] = Field(
+        default=None, description="The password used to authenticate"
+    )
+    private_key: Optional[SecretBytes] = Field(
+        default=None, description="The PEM used to authenticate"
+    )
+    authenticator: Optional[str] = Field(
+        default=None,
+        description=(
+            "The type of authenticator to use for initializing "
+            "connection (oauth, externalbrowser, etc)"
+        ),
+    )
+    token: Optional[SecretStr] = Field(
+        default=None,
+        description=(
+            "The OAuth or JWT Token to provide when " "authenticator is set to oauth"
+        ),
+    )
+    role: Optional[str] = Field(
+        default=None, description="The name of the default role to use"
+    )
+    autocommit: Optional[bool] = Field(
+        default=None, description="Whether to automatically commit"
+    )
 
     @root_validator(pre=True)
     def _validate_auth_kwargs(cls, values):
@@ -58,92 +76,3 @@ class SnowflakeCredentials(Block):
                 f"One of the authentication keys must be provided: {auth_str}\n"
             )
         return values
-
-
-class SnowflakeConnector(Block):
-
-    """
-    Block used to manage connections with Snowflake.
-
-    Args:
-        database: The name of the default database to use.
-        warehouse: The name of the default warehouse to use.
-        schema: The name of the default schema to use.
-        credentials: The credentials to authenticate with Snowflake.
-
-    Example:
-        Load stored Snowflake connector:
-        ```python
-        from prefect_snowflake import SnowflakeConnector
-        snowflake_connector_block = SnowflakeConnector.load("BLOCK_NAME")
-        ```
-    """
-
-    _block_type_name = "Snowflake Connector"
-    _logo_url = "https://images.ctfassets.net/gm98wzqotmnx/2DxzAeTM9eHLDcRQx1FR34/f858a501cdff918d398b39365ec2150f/snowflake.png?h=250"  # noqa
-
-    database: str
-    warehouse: str
-    schema_: str = Field(alias="schema")
-    credentials: SnowflakeCredentials
-
-    def _get_connect_params(self) -> Dict[str, str]:
-        """
-        Creates a connect params mapping to pass into get_connection.
-        """
-        connect_params = {
-            "database": self.database,
-            "warehouse": self.warehouse,
-            "schema": self.schema_,
-            # required to track task's usage in the Snowflake Partner Network Portal
-            "application": "Prefect_Snowflake_Collection",
-            **self.credentials.dict(),
-        }
-
-        # filter out unset values
-        connect_params = {
-            param: value for param, value in connect_params.items() if value is not None
-        }
-
-        for param in ("password", "private_key", "token"):
-            if param in connect_params:
-                connect_params[param] = connect_params[param].get_secret_value()
-
-        return connect_params
-
-    def get_connection(self) -> connector.SnowflakeConnection:
-        """
-        Returns an authenticated connection that can be
-        used to query from Snowflake databases.
-
-        Args:
-            database: The name of the database to use; overrides
-                the class definition if provided.
-            warehouse: The name of the warehouse to use; overrides
-                the class definition if provided.
-
-        Returns:
-            The authenticated SnowflakeConnection.
-
-        Examples:
-            ```python
-            from prefect import flow
-            from prefect_snowflake import SnowflakeConnector
-
-            @flow
-            def snowflake_connector_flow():
-                snowflake_connector = SnowflakeConnector(
-                    account="account",
-                    user="user",
-                    password="password",
-                    database="database",
-                    warehouse="warehouse",
-                )
-                return snowflake_connector
-
-            snowflake_connector_flow()
-            ```
-        """
-        connect_params = self._get_connect_params()
-        connection = connector.connect(**connect_params)
-        return connection

--- a/prefect_snowflake/credentials.py
+++ b/prefect_snowflake/credentials.py
@@ -81,22 +81,9 @@ class SnowflakeConnector(SnowflakeCredentials):
     _block_type_name = "Snowflake Connector"
     _logo_url = "https://images.ctfassets.net/gm98wzqotmnx/2DxzAeTM9eHLDcRQx1FR34/f858a501cdff918d398b39365ec2150f/snowflake.png?h=250"  # noqa
 
-    database: Optional[str] = None
-    warehouse: Optional[str] = None
+    database: str
+    warehouse: str
     schema_: Optional[str] = Field(alias="schema")
-
-    @root_validator(pre=True)
-    def _validate_connector_kwargs(cls, values):
-        """
-        Ensure connector values has been provided by the user.
-        """
-        connector_params = ("database", "warehouse")
-        if not all(values.get(param) for param in connector_params):
-            connector_str = ", ".join(connector_params)
-            raise ValueError(
-                f"Both of the connector keys must be provided: {connector_str}\n"
-            )
-        return values
 
     def _get_connect_params(self) -> Dict[str, str]:
         """

--- a/prefect_snowflake/credentials.py
+++ b/prefect_snowflake/credentials.py
@@ -60,7 +60,7 @@ class SnowflakeCredentials(Block):
         return values
 
 
-class SnowflakeConnector(SnowflakeCredentials):
+class SnowflakeConnector(Block):
 
     """
     Block used to manage connections with Snowflake.
@@ -69,6 +69,7 @@ class SnowflakeConnector(SnowflakeCredentials):
         database: The name of the default database to use.
         warehouse: The name of the default warehouse to use.
         schema: The name of the default schema to use.
+        credentials: The credentials to authenticate with Snowflake.
 
     Example:
         Load stored Snowflake connector:
@@ -83,26 +84,20 @@ class SnowflakeConnector(SnowflakeCredentials):
 
     database: str
     warehouse: str
-    schema_: Optional[str] = Field(alias="schema")
+    schema_: str = Field(alias="schema")
+    credentials: SnowflakeCredentials
 
     def _get_connect_params(self) -> Dict[str, str]:
         """
         Creates a connect params mapping to pass into get_connection.
         """
         connect_params = {
-            "account": self.account,
-            "user": self.user,
-            "password": self.password,
             "database": self.database,
             "warehouse": self.warehouse,
-            "private_key": self.private_key,
-            "authenticator": self.authenticator,
-            "token": self.token,
             "schema": self.schema_,
-            "role": self.role,
-            "autocommit": self.autocommit,
             # required to track task's usage in the Snowflake Partner Network Portal
             "application": "Prefect_Snowflake_Collection",
+            **self.credentials.dict(),
         }
 
         # filter out unset values

--- a/prefect_snowflake/database.py
+++ b/prefect_snowflake/database.py
@@ -18,8 +18,6 @@ async def snowflake_query(
     snowflake_connector: "SnowflakeConnector",
     params: Union[Tuple[Any], Dict[str, Any]] = None,
     cursor_type: Optional[SnowflakeCursor] = SnowflakeCursor,
-    database: Optional[str] = None,
-    warehouse: Optional[str] = None,
 ) -> List[Tuple[Any]]:
     """
     Executes a query against a Snowflake database.
@@ -29,10 +27,6 @@ async def snowflake_query(
         params: The params to replace the placeholders in the query.
         snowflake_connector: The credentials to use to authenticate.
         cursor_type: The type of database cursor to use for the query.
-        database: The name of the database to use; overrides
-            the credentials definition if provided.
-        warehouse: The name of the warehouse to use; overrides
-            the credentials definition if provided.
 
     Returns:
         The output of `response.fetchall()`.
@@ -51,8 +45,6 @@ async def snowflake_query(
                 account="account",
                 user="user",
                 password="password",
-                database="database",
-                warehouse="warehouse",
             )
             result = snowflake_query(
                 "SELECT * FROM table WHERE id=%{id_param}s LIMIT 8;",
@@ -64,9 +56,8 @@ async def snowflake_query(
         snowflake_query_flow()
         ```
     """
-    connect_params = {"database": database, "warehouse": warehouse}
     # context manager automatically rolls back failed transactions and closes
-    with snowflake_connector.get_connection(**connect_params) as connection:
+    with snowflake_connector.get_connection() as connection:
         with connection.cursor(cursor_type) as cursor:
             response = cursor.execute_async(query, params=params)
             query_id = response["queryId"]
@@ -85,8 +76,6 @@ async def snowflake_multiquery(
     snowflake_connector: "SnowflakeConnector",
     params: Union[Tuple[Any], Dict[str, Any]] = None,
     cursor_type: Optional[SnowflakeCursor] = SnowflakeCursor,
-    database: Optional[str] = None,
-    warehouse: Optional[str] = None,
     as_transaction: bool = False,
     return_transaction_control_results: bool = False,
 ) -> List[List[Tuple[Any]]]:
@@ -99,10 +88,6 @@ async def snowflake_multiquery(
         params: The params to replace the placeholders in the query.
         snowflake_connector: The credentials to use to authenticate.
         cursor_type: The type of database cursor to use for the query.
-        database: The name of the database to use; overrides
-            the credentials definition if provided.
-        warehouse: The name of the warehouse to use; overrides
-            the credentials definition if provided.
         as_transaction: If True, queries are executed in a transaction.
         return_transaction_control_results: Determines if the results of queries
             controlling the transaction (BEGIN/COMMIT) should be returned.
@@ -124,8 +109,6 @@ async def snowflake_multiquery(
                 account="account",
                 user="user",
                 password="password",
-                database="database",
-                warehouse="warehouse",
             )
             result = snowflake_multiquery(
                 ["SELECT * FROM table WHERE id=%{id_param}s LIMIT 8;", "SELECT 1,2"],
@@ -138,8 +121,7 @@ async def snowflake_multiquery(
         snowflake_multiquery_flow()
         ```
     """
-    connect_params = {"database": database, "warehouse": warehouse}
-    with snowflake_connector.get_connection(**connect_params) as connection:
+    with snowflake_connector.get_connection() as connection:
         if as_transaction:
             queries.insert(0, BEGIN_TRANSACTION_STATEMENT)
             queries.append(END_TRANSACTION_STATEMENT)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,24 @@
+import pytest
+
+from prefect_snowflake.credentials import SnowflakeCredentials
+
+
+@pytest.fixture()
+def credentials_params():
+    return {
+        "account": "account",
+        "user": "user",
+        "password": "password",
+    }
+
+
+@pytest.fixture()
+def connector_params(credentials_params):
+    snowflake_credentials = SnowflakeCredentials(**credentials_params)
+    _connector_params = {
+        "schema": "schema_input",
+        "database": "database",
+        "warehouse": "warehouse",
+        "credentials": snowflake_credentials,
+    }
+    return _connector_params

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -74,11 +74,3 @@ def test_snowflake_connector_get_connect_params_get_secret_value(connector_param
     snowflake_credentials = SnowflakeConnector(**connector_params)
     connector_params = snowflake_credentials._get_connect_params()
     assert connector_params["password"] == "password"
-
-
-@pytest.mark.parametrize("param", ("database", "warehouse"))
-def test_snowflake_connector_get_connect_params_missing_input(connector_params, param):
-    connector_params_missing = connector_params.copy()
-    connector_params_missing.pop(param)
-    with pytest.raises(ValueError, match="Both of the connector keys"):
-        SnowflakeConnector(**connector_params_missing)

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -3,18 +3,28 @@ from unittest.mock import MagicMock
 import pytest
 from pydantic import SecretStr
 
-from prefect_snowflake.credentials import SnowflakeCredentials
+from prefect_snowflake.credentials import SnowflakeConnector, SnowflakeCredentials
 
 
 @pytest.fixture()
-def connect_params():
+def credentials_params():
     return {
         "account": "account",
         "user": "user",
         "password": "password",
-        "database": "database",
-        "warehouse": "warehouse",
     }
+
+
+@pytest.fixture()
+def connector_params(credentials_params):
+    _connector_params = credentials_params.copy()
+    _connector_params.update(
+        {
+            "database": "database",
+            "warehouse": "warehouse",
+        }
+    )
+    return _connector_params
 
 
 @pytest.fixture
@@ -24,77 +34,51 @@ def snowflake_auth(monkeypatch):
     monkeypatch.setattr("snowflake.connector.connection.Auth", auth_mock)
 
 
-def test_snowflake_credentials_get_connect_params(connect_params):
-    snowflake_credentials = SnowflakeCredentials(**connect_params)
-    actual_connect_params = snowflake_credentials._get_connect_params()
-    for param in connect_params:
-        actual = actual_connect_params[param]
-        expected = connect_params[param]
+def test_snowflake_credentials_init(credentials_params):
+    snowflake_credentials = SnowflakeCredentials(**credentials_params)
+    actual_credentials_params = snowflake_credentials.dict()
+    for param in credentials_params:
+        actual = actual_credentials_params[param]
+        expected = credentials_params[param]
         if isinstance(actual, SecretStr):
             actual = actual.get_secret_value()
         assert actual == expected
 
-    valid_params = dir(SnowflakeCredentials)
-    for param in valid_params:
-        if param.startswith("_"):
-            continue
 
-        expected = getattr(snowflake_credentials, param)
-        if callable(expected):
-            continue
-
-        if expected is None:
-            # it is filtered out
-            assert param not in snowflake_credentials.connect_params
-        else:
-            # the value is correct
-            assert snowflake_credentials.connect_params[param] == expected
-
-
-def test_snowflake_credentials_validate_auth_kwargs(snowflake_auth, connect_params):
-    connect_params_missing = connect_params.copy()
-    connect_params_missing.pop("password")
+def test_snowflake_credentials_validate_auth_kwargs(credentials_params):
+    credentials_params_missing = credentials_params.copy()
+    credentials_params_missing.pop("password")
     with pytest.raises(ValueError, match="One of the authentication keys"):
-        SnowflakeCredentials(**connect_params_missing)
+        SnowflakeCredentials(**credentials_params_missing)
 
 
-def test_snowflake_credentials_get_connect_params_override(
-    snowflake_auth, connect_params
-):
-    snowflake_credentials = SnowflakeCredentials(**connect_params)
-    new_connect_params = snowflake_credentials._get_connect_params(
-        database="override_database", warehouse="override_warehouse"
-    )
-
-    for param in ["database", "warehouse"]:
-        actual = new_connect_params[param]
-        expected = "override_" + connect_params[param]
+def test_snowflake_connector_init(connector_params):
+    snowflake_credentials = SnowflakeConnector(**connector_params)
+    actual_connector_params = snowflake_credentials.dict()
+    for param in connector_params:
+        actual = actual_connector_params[param]
+        expected = connector_params[param]
+        if isinstance(actual, SecretStr):
+            actual = actual.get_secret_value()
         assert actual == expected
 
 
-def test_snowflake_credentials_get_connect_params_get_secret_value(
-    snowflake_auth, connect_params
-):
-    snowflake_credentials = SnowflakeCredentials(**connect_params)
-    connect_params = snowflake_credentials._get_connect_params()
-    assert connect_params["password"] == "password"
+def test_snowflake_connector_password_is_secret_str(connector_params):
+    snowflake_credentials = SnowflakeConnector(**connector_params)
+    password = snowflake_credentials.password
+    assert isinstance(password, SecretStr)
+    assert password.get_secret_value() == "password"
+
+
+def test_snowflake_connector_get_connect_params_get_secret_value(connector_params):
+    snowflake_credentials = SnowflakeConnector(**connector_params)
+    connector_params = snowflake_credentials._get_connect_params()
+    assert connector_params["password"] == "password"
 
 
 @pytest.mark.parametrize("param", ("database", "warehouse"))
-def test_snowflake_credentials_get_connect_params_missing_input(
-    snowflake_auth, connect_params, param
-):
-    connect_params_missing = connect_params.copy()
-    connect_params_missing.pop(param)
-    with pytest.raises(ValueError, match=f"The {param} must be set in either"):
-        SnowflakeCredentials(**connect_params_missing)._get_connect_params()
-
-
-def test_snowflake_password_is_secret_str():
-    password = "dontshowthis"
-    credentials = SnowflakeCredentials(
-        account="name_of_account", user="user", password=password
-    )
-    connect_params_password = credentials.password
-    assert isinstance(connect_params_password, SecretStr)
-    assert connect_params_password.get_secret_value() == password
+def test_snowflake_connector_get_connect_params_missing_input(connector_params, param):
+    connector_params_missing = connector_params.copy()
+    connector_params_missing.pop(param)
+    with pytest.raises(ValueError, match="Both of the connector keys"):
+        SnowflakeConnector(**connector_params_missing)

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -48,18 +48,18 @@ class SnowflakeConnection:
 
 
 @pytest.fixture()
-def snowflake_credentials():
-    snowflake_credentials_mock = MagicMock()
-    snowflake_credentials_mock.get_connection.return_value = SnowflakeConnection()
-    return snowflake_credentials_mock
+def snowflake_connector():
+    snowflake_connector_mock = MagicMock()
+    snowflake_connector_mock.get_connection.return_value = SnowflakeConnection()
+    return snowflake_connector_mock
 
 
-def test_snowflake_query(snowflake_credentials):
+def test_snowflake_query(snowflake_connector):
     @flow
     def test_flow():
         result = snowflake_query(
             "query",
-            snowflake_credentials,
+            snowflake_connector,
             params=("param",),
         )
         return result
@@ -69,12 +69,12 @@ def test_snowflake_query(snowflake_credentials):
     assert result[0][1] == ("param",)
 
 
-def test_snowflake_multiquery(snowflake_credentials):
+def test_snowflake_multiquery(snowflake_connector):
     @flow
     def test_flow():
         result = snowflake_multiquery(
             ["query1", "query2"],
-            snowflake_credentials,
+            snowflake_connector,
             params=("param",),
         )
         return result
@@ -86,12 +86,12 @@ def test_snowflake_multiquery(snowflake_credentials):
     assert result[1][0][1] == ("param",)
 
 
-def test_snowflake_multiquery_transaction(snowflake_credentials):
+def test_snowflake_multiquery_transaction(snowflake_connector):
     @flow
     def test_flow():
         result = snowflake_multiquery(
             ["query1", "query2"],
-            snowflake_credentials,
+            snowflake_connector,
             params=("param",),
             as_transaction=True,
         )
@@ -105,13 +105,13 @@ def test_snowflake_multiquery_transaction(snowflake_credentials):
 
 
 def test_snowflake_multiquery_transaction_with_transaction_control_results(
-    snowflake_credentials,
+    snowflake_connector,
 ):
     @flow
     def test_flow():
         result = snowflake_multiquery(
             ["query1", "query2"],
-            snowflake_credentials,
+            snowflake_connector,
             params=("param",),
             as_transaction=True,
             return_transaction_control_results=True,


### PR DESCRIPTION
<!-- Thanks for contributing to prefect-snowflake! 🎉-->

## Summary
<!-- A brief summary explaining the purpose of this PR -->

Refactors `SnowflakeCredentials` to utilize `pydantic.root_validator`, and migrates some keywords (`database` and `warehouse`) plus a method (`get_connection`) into `SnowflakeConnector`

Based on
> This implementation looks good, but I wonder if maybe we should swap out `block_initialization` for `_get_connection_params`. That way we wouldn't be storing duplication information on the class, and we wouldn't have to introduce extra logic passing around secret values. Might be worth exploring.
https://github.com/PrefectHQ/prefect-snowflake/pull/22#pullrequestreview-1062235030

## Relevant Issue(s)
<!-- If this PR addresses any open issues, please let us know which one here -->
#21

## Checklist
- [x] Summarized PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-snowflake/blob/main/CHANGELOG.md)
