### PR TITLE
Makes authenticator a literal type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - `SnowflakeConnector` block - [#24](https://github.com/PrefectHQ/prefect-snowflake/pull/24)
+- `okta_endpoint` field to `SnowflakeCredentials` - [#25](https://github.com/PrefectHQ/prefect-snowflake/pull/25)
 
 ### Changed
 - Moved the keywords, `database` and `warehouse`, from `credentials.SnowflakeCredentials` into `database.SnowflakeConnector` - [#24](https://github.com/PrefectHQ/prefect-snowflake/pull/24)
 - Moved the method `get_connection` from `credentials.SnowflakeCredentials` into `database.SnowflakeConnector` - [#24](https://github.com/PrefectHQ/prefect-snowflake/pull/24)
+- `authenticator` field in `SnowflakeCredentials` to `Literal` type - [#25](https://github.com/PrefectHQ/prefect-snowflake/pull/25)
 
 ### Deprecated
 

--- a/prefect_snowflake/credentials.py
+++ b/prefect_snowflake/credentials.py
@@ -102,7 +102,7 @@ class SnowflakeCredentials(Block):
         token = values.get("token")
         if authenticator == "oauth" and not token:
             raise ValueError(
-                "If authenticator is set to `oauth`, `token` must be provided\n"
+                "If authenticator is set to `oauth`, `token` must be provided"
             )
         return values
 

--- a/prefect_snowflake/credentials.py
+++ b/prefect_snowflake/credentials.py
@@ -116,6 +116,6 @@ class SnowflakeCredentials(Block):
         if authenticator == "okta_endpoint" and not okta_endpoint:
             raise ValueError(
                 "If authenticator is set to `okta_endpoint`, "
-                "`okta_endpoint` must be provided\n"
+                "`okta_endpoint` must be provided"
             )
         return values

--- a/prefect_snowflake/credentials.py
+++ b/prefect_snowflake/credentials.py
@@ -1,6 +1,11 @@
 """Credentials class to authenticate Snowflake."""
 
-from typing import Literal, Optional
+from typing import Optional
+
+try:
+    from typing import Literal
+except ImportError:
+    from typing_extensions import Literal
 
 from prefect.blocks.core import Block
 from pydantic import Field, SecretBytes, SecretStr, root_validator

--- a/prefect_snowflake/database.py
+++ b/prefect_snowflake/database.py
@@ -68,6 +68,10 @@ class SnowflakeConnector(Block):
             if param in connect_params:
                 connect_params[param] = connect_params[param].get_secret_value()
 
+        # set authenticator to the actual okta_endpoint
+        if connect_params.get("okta_endpoint"):
+            connect_params["authenticator"] = connect_params.pop("okta_endpoint")
+
         return connect_params
 
     def get_connection(self) -> snowflake.connector.SnowflakeConnection:

--- a/prefect_snowflake/database.py
+++ b/prefect_snowflake/database.py
@@ -69,7 +69,7 @@ class SnowflakeConnector(Block):
                 connect_params[param] = connect_params[param].get_secret_value()
 
         # set authenticator to the actual okta_endpoint
-        if connect_params.get("okta_endpoint"):
+        if connect_params.get("authenticator") == "okta_endpoint":
             connect_params["authenticator"] = connect_params.pop("okta_endpoint")
 
         return connect_params

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,24 @@
+import pytest
+
+from prefect_snowflake.credentials import SnowflakeCredentials
+
+
+@pytest.fixture()
+def credentials_params():
+    return {
+        "account": "account",
+        "user": "user",
+        "password": "password",
+    }
+
+
+@pytest.fixture()
+def connector_params(credentials_params):
+    snowflake_credentials = SnowflakeCredentials(**credentials_params)
+    _connector_params = {
+        "schema": "schema_input",
+        "database": "database",
+        "warehouse": "warehouse",
+        "credentials": snowflake_credentials,
+    }
+    return _connector_params

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -29,3 +29,27 @@ def test_snowflake_credentials_validate_auth_kwargs(credentials_params):
     credentials_params_missing.pop("password")
     with pytest.raises(ValueError, match="One of the authentication keys"):
         SnowflakeCredentials(**credentials_params_missing)
+
+
+def test_snowflake_credentials_validate_token_kwargs(credentials_params):
+    credentials_params_missing = credentials_params.copy()
+    credentials_params_missing.pop("password")
+    credentials_params_missing["authenticator"] = "oauth"
+    with pytest.raises(ValueError, match="If authenticator is set to `oauth`"):
+        SnowflakeCredentials(**credentials_params_missing)
+
+    # now test if passing both works
+    credentials_params_missing["token"] = "some_token"
+    assert SnowflakeCredentials(**credentials_params_missing)
+
+
+def test_snowflake_credentials_validate_okta_endpoint_kwargs(credentials_params):
+    credentials_params_missing = credentials_params.copy()
+    credentials_params_missing.pop("password")
+    credentials_params_missing["authenticator"] = "okta_endpoint"
+    with pytest.raises(ValueError, match="If authenticator is set to `okta_endpoint`"):
+        SnowflakeCredentials(**credentials_params_missing)
+
+    # now test if passing both works
+    credentials_params_missing["okta_endpoint"] = "https://account_name.okta.com"
+    assert SnowflakeCredentials(**credentials_params_missing)

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -35,8 +35,20 @@ def test_snowflake_connector_password_is_secret_str(connector_params):
 
 def test_snowflake_connector_get_connect_params_get_secret_value(connector_params):
     snowflake_connector = SnowflakeConnector(**connector_params)
-    connector_params = snowflake_connector._get_connect_params()
-    assert connector_params["password"] == "password"
+    connect_params = snowflake_connector._get_connect_params()
+    assert connect_params["password"] == "password"
+
+
+def test_snowflake_connector_get_connect_params_okta_endpoint(connector_params):
+    okta_endpoint = "https://account_name.okta.com"
+    connector_params_okta_endpoint = connector_params.copy()
+    connector_params_okta_endpoint["credentials"].password = None
+    connector_params_okta_endpoint["credentials"].authenticator = "okta_endpoint"
+    connector_params_okta_endpoint["credentials"].okta_endpoint = okta_endpoint
+    snowflake_connector = SnowflakeConnector(**connector_params_okta_endpoint)
+    connect_params = snowflake_connector._get_connect_params()
+    assert connect_params["authenticator"] == okta_endpoint
+    assert connect_params.get("okta_endpoint") is None
 
 
 class SnowflakeCursor:


### PR DESCRIPTION
<!-- Thanks for contributing to prefect-snowflake! 🎉-->

## Summary
<!-- A brief summary explaining the purpose of this PR -->
Makes authenticator a literal type since there are only some valid choices, except okta endpoints, which can be unlimited, so there's a separate keyword for that.

![image](https://user-images.githubusercontent.com/15331990/184403283-05c2f98f-6c5c-43ae-9c9f-8aeaa467b7ac.png)


## Relevant Issue(s)
<!-- If this PR addresses any open issues, please let us know which one here -->

## Checklist
- [ ] Summarized PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-snowflake/blob/main/CHANGELOG.md)
