### PR TITLE
Fix okta endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
+- The `okta_endpoint` field in `SnowflakeCredentials`; use `endpoint` instead - [#45](https://github.com/PrefectHQ/prefect-snowflake/pull/45).
+
 ### Removed
 
 ### Fixed
+
+- Fixed misleading validator message in `SnowflakeCredentials` when `authenticator` is `okta_endpoint` - [#45](https://github.com/PrefectHQ/prefect-snowflake/pull/45).
 
 ### Security
 

--- a/prefect_snowflake/credentials.py
+++ b/prefect_snowflake/credentials.py
@@ -137,11 +137,11 @@ class SnowflakeCredentials(Block):
         Ensure an authorization value has been provided by the user.
         """
         authenticator = values.get("authenticator")
-        okta_endpoint = values.get("okta_endpoint")
-        if authenticator == "okta_endpoint" and not okta_endpoint:
+        endpoint = values.get("endpoint")
+        if authenticator == "okta_endpoint" and not endpoint:
             raise ValueError(
                 "If authenticator is set to `okta_endpoint`, "
-                "`okta_endpoint` must be provided"
+                "`endpoint` must be provided"
             )
         return values
 

--- a/prefect_snowflake/credentials.py
+++ b/prefect_snowflake/credentials.py
@@ -1,6 +1,7 @@
 """Credentials class to authenticate Snowflake."""
 
 import re
+import warnings
 from typing import Optional, Union
 
 from cryptography.hazmat.backends import default_backend
@@ -137,6 +138,19 @@ class SnowflakeCredentials(Block):
         Ensure an authorization value has been provided by the user.
         """
         authenticator = values.get("authenticator")
+
+        # did not want to make a breaking change so we will allow both
+        # see https://github.com/PrefectHQ/prefect-snowflake/issues/44
+        if "okta_endpoint" in values.keys():
+            warnings.warn(
+                "Please specify `endpoint` instead of `okta_endpoint`.",
+                DeprecationWarning,
+            )
+            # remove okta endpoint from fields
+            okta_endpoint = values.pop("okta_endpoint")
+            if "endpoint" not in values.keys():
+                values["endpoint"] = okta_endpoint
+
         endpoint = values.get("endpoint")
         if authenticator == "okta_endpoint" and not endpoint:
             raise ValueError(

--- a/prefect_snowflake/database.py
+++ b/prefect_snowflake/database.py
@@ -69,7 +69,10 @@ class SnowflakeConnector(Block):
 
         # set authenticator to the actual okta_endpoint
         if connect_params.get("authenticator") == "okta_endpoint":
-            connect_params["authenticator"] = connect_params.pop("okta_endpoint")
+            endpoint = connect_params.pop("endpoint", None) or connect_params.pop(
+                "okta_endpoint", None
+            )  # okta_endpoint is deprecated
+            connect_params["authenticator"] = endpoint
 
         private_der_key = self.credentials.resolve_private_key()
         if private_der_key is not None:

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -52,7 +52,29 @@ def test_snowflake_credentials_validate_okta_endpoint_kwargs(credentials_params)
 
     # now test if passing both works
     credentials_params_missing["endpoint"] = "https://account_name.okta.com"
-    assert SnowflakeCredentials(**credentials_params_missing)
+    snowflake_credentials = SnowflakeCredentials(**credentials_params_missing)
+    assert snowflake_credentials.endpoint == "https://account_name.okta.com"
+
+
+def test_snowflake_credentials_support_deprecated_okta_endpoint(credentials_params):
+    credentials_params_missing = credentials_params.copy()
+    credentials_params_missing.pop("password")
+    credentials_params_missing["authenticator"] = "okta_endpoint"
+    credentials_params_missing["okta_endpoint"] = "deprecated.com"
+    snowflake_credentials = SnowflakeCredentials(**credentials_params_missing)
+    assert snowflake_credentials.endpoint == "deprecated.com"
+
+
+def test_snowflake_credentials_support_endpoint_overrides_okta_endpoint(
+    credentials_params,
+):
+    credentials_params_missing = credentials_params.copy()
+    credentials_params_missing.pop("password")
+    credentials_params_missing["authenticator"] = "okta_endpoint"
+    credentials_params_missing["okta_endpoint"] = "deprecated.com"
+    credentials_params_missing["endpoint"] = "new.com"
+    snowflake_credentials = SnowflakeCredentials(**credentials_params_missing)
+    assert snowflake_credentials.endpoint == "new.com"
 
 
 def test_snowflake_private_credentials_init(private_credentials_params):

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -51,7 +51,7 @@ def test_snowflake_credentials_validate_okta_endpoint_kwargs(credentials_params)
         SnowflakeCredentials(**credentials_params_missing)
 
     # now test if passing both works
-    credentials_params_missing["okta_endpoint"] = "https://account_name.okta.com"
+    credentials_params_missing["endpoint"] = "https://account_name.okta.com"
     assert SnowflakeCredentials(**credentials_params_missing)
 
 

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -40,7 +40,22 @@ def test_snowflake_connector_get_connect_params_get_secret_value(connector_param
     assert connect_params["password"] == "password"
 
 
-def test_snowflake_connector_get_connect_params_okta_endpoint(connector_params):
+def test_snowflake_connector_get_connect_params_endpoint(connector_params):
+    okta_endpoint = "https://account_name.okta.com"
+    connector_params_okta_endpoint = connector_params.copy()
+    connector_params_okta_endpoint["credentials"].password = None
+    connector_params_okta_endpoint["credentials"].authenticator = "okta_endpoint"
+    connector_params_okta_endpoint["credentials"].endpoint = okta_endpoint
+    snowflake_connector = SnowflakeConnector(**connector_params_okta_endpoint)
+    connect_params = snowflake_connector._get_connect_params()
+    assert connect_params["authenticator"] == okta_endpoint
+    assert connect_params.get("okta_endpoint") is None
+    assert connect_params.get("endpoint") is None
+
+
+def test_snowflake_connector_get_connect_params_deprecated_okta_endpoint(
+    connector_params,
+):
     okta_endpoint = "https://account_name.okta.com"
     connector_params_okta_endpoint = connector_params.copy()
     connector_params_okta_endpoint["credentials"].password = None
@@ -50,6 +65,7 @@ def test_snowflake_connector_get_connect_params_okta_endpoint(connector_params):
     connect_params = snowflake_connector._get_connect_params()
     assert connect_params["authenticator"] == okta_endpoint
     assert connect_params.get("okta_endpoint") is None
+    assert connect_params.get("endpoint") is None
 
 
 def test_snowflake_connector_private_key_is_secret(private_connector_params):


### PR DESCRIPTION
<!-- Thanks for contributing to prefect-snowflake! 🎉-->

## Summary
<!-- A brief summary explaining the purpose of this PR -->

The validator tells users that they must specify `okta_endpoint`

However, `okta_endpoint` keyword arg is not officially a field in the pydantic model--`endpoint` is.

However, if users did listen to the misleading advice of the validator to specify `okta_endpoint` kwarg, didn't want to make a breaking change, so I'm deprecating it and telling users to use `endpoint` instead.

## Relevant Issue(s)
<!-- If this PR addresses any open issues, please let us know which one here -->

Closes https://github.com/PrefectHQ/prefect-snowflake/issues/44

## Checklist
- [ ] Summarized PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-snowflake/blob/main/CHANGELOG.md)
