### PR TITLE
prep-0.2.3-release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,15 +11,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
-- The `okta_endpoint` field in `SnowflakeCredentials`; use `endpoint` instead - [#45](https://github.com/PrefectHQ/prefect-snowflake/pull/45).
-
 ### Removed
 
 ### Fixed
 
-- Fixed misleading validator message in `SnowflakeCredentials` when `authenticator` is `okta_endpoint` - [#45](https://github.com/PrefectHQ/prefect-snowflake/pull/45).
-
 ### Security
+
+## 0.2.3
+
+Released on December 21st, 2022.
+
+### Deprecated
+
+- The `okta_endpoint` field in `SnowflakeCredentials`; use `endpoint` instead - [#45](https://github.com/PrefectHQ/prefect-snowflake/pull/45).
+
+### Fixed
+
+- Fixed misleading validator message in `SnowflakeCredentials` when `authenticator` is `okta_endpoint` - [#45](https://github.com/PrefectHQ/prefect-snowflake/pull/45).
 
 ## 0.2.2
 


### PR DESCRIPTION
<!-- Thanks for contributing to prefect-snowflake! 🎉-->

## Summary
<!-- A brief summary explaining the purpose of this PR -->

The validator tells users that they must specify `okta_endpoint`

However, `okta_endpoint` keyword arg is not officially a field in the pydantic model--`endpoint` is.

However, if users did listen to the misleading advice of the validator to specify `okta_endpoint` kwarg, didn't want to make a breaking change, so I'm deprecating it and telling users to use `endpoint` instead.

## Relevant Issue(s)
<!-- If this PR addresses any open issues, please let us know which one here -->

Closes https://github.com/PrefectHQ/prefect-snowflake/issues/44

## Checklist
- [ ] Summarized PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-snowflake/blob/main/CHANGELOG.md)
