### PR TITLE
Dont start connection

### DIFF
--- a/prefect_snowflake/database.py
+++ b/prefect_snowflake/database.py
@@ -147,19 +147,14 @@ class SnowflakeConnector(DatabaseBlock):
             "schema": self.schema_,
         }
         connection = self.credentials.get_client(**connect_kwargs, **connect_params)
+        self._connection = connection
         return connection
 
     def _start_connection(self):
         """
         Starts Snowflake database connection.
         """
-        self._connection = self.get_connection()
-
-    def block_initialization(self) -> None:
-        super().block_initialization()
-        if self._connection is None:
-            self._start_connection()
-
+        self.get_connection()
         if self._unique_cursors is None:
             self._unique_cursors = {}
 
@@ -174,6 +169,8 @@ class SnowflakeConnector(DatabaseBlock):
         Returns:
             Whether a cursor is new and a Snowflake cursor.
         """
+        self._start_connection()
+
         input_hash = hash_objects(inputs)
         if input_hash is None:
             raise RuntimeError(
@@ -232,6 +229,10 @@ class SnowflakeConnector(DatabaseBlock):
                 print(conn.fetch_one("SELECT * FROM customers"))  # should be Ford again
             ```
         """  # noqa
+        if not self._unique_cursors:
+            self.logger.info("There are no cursors to reset.")
+            return
+
         input_hashes = tuple(self._unique_cursors.keys())
         for input_hash in input_hashes:
             cursor = self._unique_cursors.pop(input_hash)
@@ -462,6 +463,8 @@ class SnowflakeConnector(DatabaseBlock):
                 )
             ```
         """  # noqa
+        self._start_connection()
+
         inputs = dict(
             command=operation,
             params=parameters,
@@ -506,6 +509,8 @@ class SnowflakeConnector(DatabaseBlock):
                 )
             ```
         """  # noqa
+        self._start_connection()
+
         inputs = dict(
             command=operation,
             seqparams=seq_of_parameters,
@@ -549,7 +554,6 @@ class SnowflakeConnector(DatabaseBlock):
     def __setstate__(self, data: dict):
         """Reset connection and cursors upon loading."""
         self.__dict__.update(data)
-        self._unique_cursors = {}
         self._start_connection()
 
 

--- a/prefect_snowflake/database.py
+++ b/prefect_snowflake/database.py
@@ -148,6 +148,7 @@ class SnowflakeConnector(DatabaseBlock):
         }
         connection = self.credentials.get_client(**connect_kwargs, **connect_params)
         self._connection = connection
+        self.logger.info("Started a new connection to Snowflake.")
         return connection
 
     def _start_connection(self):

--- a/prefect_snowflake/database.py
+++ b/prefect_snowflake/database.py
@@ -230,7 +230,7 @@ class SnowflakeConnector(DatabaseBlock):
             ```
         """  # noqa
         if not self._unique_cursors:
-            self.logger.info("There are no cursors to reset.")
+            self.logger.info("There were no cursors to reset.")
             return
 
         input_hashes = tuple(self._unique_cursors.keys())
@@ -528,10 +528,12 @@ class SnowflakeConnector(DatabaseBlock):
         try:
             self.reset_cursors()
         finally:
-            if self._connection is not None:
-                self._connection.close()
-                self._connection = None
-        self.logger.info("Successfully closed the Snowflake connection.")
+            if self._connection is None:
+                self.logger.info("There was no connection open to be closed.")
+                return
+            self._connection.close()
+            self._connection = None
+            self.logger.info("Successfully closed the Snowflake connection.")
 
     def __enter__(self):
         """

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -195,9 +195,10 @@ class TestSnowflakeConnector:
         assert snowflake_connector._connection is None
         assert snowflake_connector._unique_cursors is None
 
-    def test_get_connection(self, snowflake_connector: SnowflakeConnector):
+    def test_get_connection(self, snowflake_connector: SnowflakeConnector, caplog):
         connection = snowflake_connector.get_connection()
         assert snowflake_connector._connection is connection
+        assert caplog.records[0].msg == "Started a new connection to Snowflake."
 
     def test_reset_cursors(self, snowflake_connector: SnowflakeConnector, caplog):
         mock_cursor = MagicMock()

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -192,15 +192,19 @@ class TestSnowflakeConnector:
         return connector
 
     def test_block_initialization(self, snowflake_connector):
-        assert snowflake_connector._connection is not None
-        assert snowflake_connector._unique_cursors == {}
+        assert snowflake_connector._connection is None
+        assert snowflake_connector._unique_cursors is None
 
     def test_get_connection(self, snowflake_connector: SnowflakeConnector):
         connection = snowflake_connector.get_connection()
         assert snowflake_connector._connection is connection
 
-    def test_reset_cursors(self, snowflake_connector: SnowflakeConnector):
+    def test_reset_cursors(self, snowflake_connector: SnowflakeConnector, caplog):
         mock_cursor = MagicMock()
+        snowflake_connector.reset_cursors()
+        assert caplog.records[0].msg == "There are no cursors to reset."
+
+        snowflake_connector._start_connection()
         snowflake_connector._unique_cursors["12345"] = mock_cursor
         snowflake_connector.reset_cursors()
         assert len(snowflake_connector._unique_cursors) == 0
@@ -232,12 +236,15 @@ class TestSnowflakeConnector:
         )
 
     def test_close(self, snowflake_connector: SnowflakeConnector):
+        snowflake_connector._start_connection()
         assert snowflake_connector.close() is None
         assert snowflake_connector._connection is None
         assert snowflake_connector._unique_cursors == {}
 
     def test_context_management(self, snowflake_connector):
         with snowflake_connector:
-            pass
+            assert snowflake_connector._connection is None
+            assert snowflake_connector._unique_cursors is None
+
         assert snowflake_connector._connection is None
-        assert snowflake_connector._unique_cursors == {}
+        assert snowflake_connector._unique_cursors is None

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -202,7 +202,7 @@ class TestSnowflakeConnector:
     def test_reset_cursors(self, snowflake_connector: SnowflakeConnector, caplog):
         mock_cursor = MagicMock()
         snowflake_connector.reset_cursors()
-        assert caplog.records[0].msg == "There are no cursors to reset."
+        assert caplog.records[0].msg == "There were no cursors to reset."
 
         snowflake_connector._start_connection()
         snowflake_connector._unique_cursors["12345"] = mock_cursor
@@ -235,7 +235,11 @@ class TestSnowflakeConnector:
             is None
         )
 
-    def test_close(self, snowflake_connector: SnowflakeConnector):
+    def test_close(self, snowflake_connector: SnowflakeConnector, caplog):
+        assert snowflake_connector.close() is None
+        assert caplog.records[0].msg == "There were no cursors to reset."
+        assert caplog.records[1].msg == "There was no connection open to be closed."
+
         snowflake_connector._start_connection()
         assert snowflake_connector.close() is None
         assert snowflake_connector._connection is None


### PR DESCRIPTION
<!-- Thanks for contributing 🎉! Please ensure the title neatly summarizes the proposed changes. -->

<!-- Overview -->

User wanted to be able to use SnowflakeConnector purely to populate the dbt profile and then run dbt; however, in recent PRs, a connection started whenever SnowflakeConnector was instantiated.

This PR delays starting a connection until required.

Originally from https://prefect-community.slack.com/archives/CL09KU1K7/p1672777811532289?thread_ts=1671766851.641279&cid=CL09KU1K7

### Example
<!-- A code blurb is best. Changes to features should include an example that is executable by a new user. -->

### Screenshots
<!--
Any relevant screenshots
  - The updated docs page from `mkdocs serve`.
  - Output from running the example.
  - Service integration test results.
-->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-snowflake/issues/new/choose) first.
- [ ] Includes tests or only affects documentation.
- [ ] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [ ] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
- [ ] Summarizes PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-snowflake/blob/main/CHANGELOG.md)
