### PR TITLE
Fix private key validator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
-## 0.2.6
+## 0.26.0
 
 Released on January 9th, 2022.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,13 +19,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
-## 0.2.5
+## 0.2.6
+
+Released on January 9th, 2022.
+
+### Fixed
+
+- Improper validation of `private_key_path` and `private_key_passphrase` fields to `SnowflakeCredentials` - [#59](https://github.com/PrefectHQ/prefect-snowflake/pull/59)
+
+## 0.25
 
 Released on January 4th, 2022.
 
 ### Added
 
-- `private_key_path` and `private_key_passphrase` fields to `SnowflakeConnector` - [#59](https://github.com/PrefectHQ/prefect-snowflake/pull/59)
+- `private_key_path` and `private_key_passphrase` fields to `SnowflakeCredentials` - [#59](https://github.com/PrefectHQ/prefect-snowflake/pull/59)
 
 ### Changed
 

--- a/prefect_snowflake/credentials.py
+++ b/prefect_snowflake/credentials.py
@@ -137,16 +137,17 @@ class SnowflakeCredentials(CredentialsBlock):
             "authenticator",
             "token",
         )
+        print(values)
         if not any(values.get(param) for param in auth_params):
             auth_str = ", ".join(auth_params)
             raise ValueError(
                 f"One of the authentication keys must be provided: {auth_str}\n"
             )
-        elif "private_key" in values and "private_key_path" in values:
+        elif values.get("private_key") and values.get("private_key_path"):
             raise ValueError(
                 "Do not provide both private_key and private_key_path; select one."
             )
-        elif "password" in values and "private_key_passphrase" in values:
+        elif values.get("password") and values.get("private_key_passphrase"):
             raise ValueError(
                 "Do not provide both password and private_key_passphrase; "
                 "specify private_key_passphrase only instead."

--- a/prefect_snowflake/credentials.py
+++ b/prefect_snowflake/credentials.py
@@ -137,7 +137,6 @@ class SnowflakeCredentials(CredentialsBlock):
             "authenticator",
             "token",
         )
-        print(values)
         if not any(values.get(param) for param in auth_params):
             auth_str = ", ".join(auth_params)
             raise ValueError(


### PR DESCRIPTION
<!-- Thanks for contributing 🎉! Please ensure the title neatly summarizes the proposed changes. -->

<!-- Overview -->

Apparently, fields' values get populated (defaults) to None upon instantiated (see screenshot).

Then when it gets passed to another block, it causes the validator to trigger again and raise an error.

Also, in the previous release, I left out a `.` (expected 0.2.5, but now it's 0.25, sad face) so the next release will have to be 0.26.0. I updated the tags description and title to correspond to pypi's 0.25.

Closes https://github.com/PrefectHQ/prefect-snowflake/issues/62

### Example
<!-- A code blurb is best. Changes to features should include an example that is executable by a new user. -->

### Screenshots
<!--
Any relevant screenshots
  - The updated docs page from `mkdocs serve`.
  - Output from running the example.
  - Service integration test results.
-->

```
from prefect_snowflake import SnowflakeConnector, SnowflakeCredentials
from prefect import flow

@flow
def snowflake_query_flow():
    snowflake_credentials = SnowflakeCredentials(
        account="account",
        user="user",
        password="password",
        role="MY_ROLE"
    )
    snowflake_connector = SnowflakeConnector(
        database="database",
        warehouse="warehouse",
        schema="schema",
        credentials=snowflake_credentials
    )
    return snowflake_connector

snowflake_query_flow()
```

![image](https://user-images.githubusercontent.com/15331990/211214662-3edd6bea-7336-4321-b350-3d763ee2b0c9.png)

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-snowflake/issues/new/choose) first.
- [x] Includes tests or only affects documentation.
- [x] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [x] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
- [x] Summarizes PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-snowflake/blob/main/CHANGELOG.md)
