### PR TITLE
Conditional imports to support operating with `pydantic>2` installed

### DIFF
--- a/prefect_snowflake/credentials.py
+++ b/prefect_snowflake/credentials.py
@@ -20,7 +20,12 @@ except ImportError:
 
 import snowflake.connector
 from prefect.blocks.abstract import CredentialsBlock
-from pydantic import Field, SecretBytes, SecretField, SecretStr, root_validator
+from pydantic import VERSION as PYDANTIC_VERSION
+
+if PYDANTIC_VERSION.startswith("2."):
+    from pydantic.v1 import Field, SecretBytes, SecretField, SecretStr, root_validator
+else:
+    from pydantic import Field, SecretBytes, SecretField, SecretStr, root_validator
 
 # PEM certificates have the pattern:
 #   -----BEGIN PRIVATE KEY-----

--- a/prefect_snowflake/database.py
+++ b/prefect_snowflake/database.py
@@ -7,7 +7,13 @@ from prefect import task
 from prefect.blocks.abstract import DatabaseBlock
 from prefect.utilities.asyncutils import run_sync_in_worker_thread, sync_compatible
 from prefect.utilities.hashing import hash_objects
-from pydantic import Field
+from pydantic import VERSION as PYDANTIC_VERSION
+
+if PYDANTIC_VERSION.startswith("2."):
+    from pydantic.v1 import Field
+else:
+    from pydantic import Field
+
 from snowflake.connector.connection import SnowflakeConnection
 from snowflake.connector.cursor import SnowflakeCursor
 

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -5,7 +5,12 @@ from unittest.mock import MagicMock
 import pytest
 from prefect import flow
 from prefect.utilities.filesystem import relative_path_to_current_platform
-from pydantic import SecretBytes, SecretStr
+from pydantic import VERSION as PYDANTIC_VERSION
+
+if PYDANTIC_VERSION.startswith("2."):
+    from pydantic.v1 import SecretBytes, SecretStr
+else:
+    from pydantic import SecretBytes, SecretStr
 
 from prefect_snowflake.credentials import InvalidPemFormat, SnowflakeCredentials
 from prefect_snowflake.database import SnowflakeConnector

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -2,7 +2,13 @@ from unittest.mock import MagicMock
 
 import pytest
 from prefect import flow
-from pydantic import SecretBytes, SecretStr
+from pydantic import VERSION as PYDANTIC_VERSION
+
+if PYDANTIC_VERSION.startswith("2."):
+    from pydantic.v1 import SecretBytes, SecretStr
+else:
+    from pydantic import SecretBytes, SecretStr
+
 from snowflake.connector import DictCursor
 from snowflake.connector.cursor import SnowflakeCursor as OriginalSnowflakeCursorClass
 


### PR DESCRIPTION
Following the compatibility work we've done in `prefect`, we also want to apply the
same compatibility changes to all Prefect-maintained collections.  We're following the
convention that Prefect will always use `pydantic<2` idioms, leaning on the 
`pydantic.v1` module of `pydantic>2` to aid us in this.  With these changes, we can
operate normally regardless of the installed version.

Until `prefect` fully deprecates `pydantic` versions below 2.0, we'll continue to 
maintain that constraint of using only v1 idioms.

This is part of a series of identical PRs for all of our maintained collections.