### PR TITLE
User provided connect kwargs should have precedence over the default.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Ability to specify what kind of cursor is used in a query - [#71](https://github.com/PrefectHQ/prefect-snowflake/pull/71)
+- User-provided connect kwargs have precedence over the default - [#97] (https://github.com/PrefectHQ/prefect-snowflake/pull/97)
 ### Changed
 
 ### Deprecated

--- a/prefect_snowflake/credentials.py
+++ b/prefect_snowflake/credentials.py
@@ -320,10 +320,10 @@ class SnowflakeCredentials(CredentialsBlock):
             ```
         """  # noqa
         connect_params = {
-            **connect_kwargs,
             # required to track task's usage in the Snowflake Partner Network Portal
             "application": "Prefect_Snowflake_Collection",
             **self.dict(exclude_unset=True, exclude={"block_type_slug"}),
+            **connect_kwargs,
         }
 
         for key, value in connect_params.items():

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -398,3 +398,12 @@ def test_snowflake_with_private_key_path_flow():
         == "passphrase"
     )
     assert snowflake_connector.credentials.password is None
+
+
+def test_snowflake_connect_params(credentials_params, snowflake_connect_mock):
+    snowflake_credentials = SnowflakeCredentials(**credentials_params)
+
+    # The returned client is mocked, use the fixture instead
+    _ = snowflake_credentials.get_client(autocommit=False)
+
+    assert snowflake_connect_mock.call_args_list[0][1]["autocommit"] is False


### PR DESCRIPTION
<!-- Thanks for contributing 🎉! Please ensure the title neatly summarizes the proposed changes. -->

<!-- Overview -->

Closes #96 

### Example
`with snowflake_connector.get_connection(autocommit=False) as conn:` used to yield a `conn` object that still has `autocommit` set to None. Now it's set to `False` as the dev asked.

### Screenshots
<!--
Any relevant screenshots
  - The updated docs page from `mkdocs serve`.
  - Output from running the example.
  - Service integration test results.
-->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-snowflake/issues/new/choose) first.
- [x] Includes tests or only affects documentation.
- [x] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [x] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
- [x] Summarizes PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-snowflake/blob/main/CHANGELOG.md)
