### PR TITLE
Fix type hints for **kwargs to match PEP-484

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Ability to specify what kind of cursor is used in a query - [#71](https://github.com/PrefectHQ/prefect-snowflake/pull/71)
 - User-provided connect kwargs have precedence over the default - [#97] (https://github.com/PrefectHQ/prefect-snowflake/pull/97)
+- Type hints for **kwargs are now parsed correctly - [#98] (https://github.com/PrefectHQ/prefect-snowflake/pull/98)
 ### Changed
 
 ### Deprecated

--- a/prefect_snowflake/credentials.py
+++ b/prefect_snowflake/credentials.py
@@ -3,7 +3,7 @@
 import re
 import warnings
 from pathlib import Path
-from typing import Any, Dict, Optional, Union
+from typing import Any, Optional, Union
 
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.serialization import (
@@ -283,7 +283,7 @@ class SnowflakeCredentials(CredentialsBlock):
         return f"{pem_parts[1]}\n{body}\n{pem_parts[3]}".encode()
 
     def get_client(
-        self, **connect_kwargs: Dict[str, Any]
+        self, **connect_kwargs: Any
     ) -> snowflake.connector.SnowflakeConnection:
         """
         Returns an authenticated connection that can be used to query

--- a/prefect_snowflake/database.py
+++ b/prefect_snowflake/database.py
@@ -113,7 +113,7 @@ class SnowflakeConnector(DatabaseBlock):
     _connection: Optional[SnowflakeConnection] = None
     _unique_cursors: Dict[str, SnowflakeCursor] = None
 
-    def get_connection(self, **connect_kwargs: Dict[str, Any]) -> SnowflakeConnection:
+    def get_connection(self, **connect_kwargs: Any) -> SnowflakeConnection:
         """
         Returns an authenticated connection that can be
         used to query from Snowflake databases.
@@ -264,7 +264,7 @@ class SnowflakeConnector(DatabaseBlock):
         operation: str,
         parameters: Optional[Dict[str, Any]] = None,
         cursor_type: Type[SnowflakeCursor] = SnowflakeCursor,
-        **execute_kwargs: Dict[str, Any],
+        **execute_kwargs: Any,
     ) -> Tuple[Any]:
         """
         Fetch a single result from the database.
@@ -326,7 +326,7 @@ class SnowflakeConnector(DatabaseBlock):
         parameters: Optional[Dict[str, Any]] = None,
         size: Optional[int] = None,
         cursor_type: Type[SnowflakeCursor] = SnowflakeCursor,
-        **execute_kwargs: Dict[str, Any],
+        **execute_kwargs: Any,
     ) -> List[Tuple[Any]]:
         """
         Fetch a limited number of results from the database.
@@ -398,7 +398,7 @@ class SnowflakeConnector(DatabaseBlock):
         operation: str,
         parameters: Optional[Dict[str, Any]] = None,
         cursor_type: Type[SnowflakeCursor] = SnowflakeCursor,
-        **execute_kwargs: Dict[str, Any],
+        **execute_kwargs: Any,
     ) -> List[Tuple[Any]]:
         """
         Fetch all results from the database.
@@ -460,7 +460,7 @@ class SnowflakeConnector(DatabaseBlock):
         operation: str,
         parameters: Optional[Dict[str, Any]] = None,
         cursor_type: Type[SnowflakeCursor] = SnowflakeCursor,
-        **execute_kwargs: Dict[str, Any],
+        **execute_kwargs: Any,
     ) -> None:
         """
         Executes an operation on the database. This method is intended to be used


### PR DESCRIPTION
I just learned this today as I was figuring out why my IDE was flagging the type hints as wrong but kwargs should be hinted as the value in the dict and not as a dict itself. See [PEP-484](https://peps.python.org/pep-0484/#arbitrary-argument-lists-and-default-argument-values).


<!-- Overview -->

Closes

### Example
<!-- A code blurb is best. Changes to features should include an example that is executable by a new user. -->

### Screenshots
<!--
Any relevant screenshots
  - The updated docs page from `mkdocs serve`.
  - Output from running the example.
  - Service integration test results.
-->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-snowflake/issues/new/choose) first.
- [x] Includes tests or only affects documentation.
- [x] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [x] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
- [x] Summarizes PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-snowflake/blob/main/CHANGELOG.md)
