### PR TITLE
Use correct type for private key

### DIFF
--- a/prefect_snowflake/credentials.py
+++ b/prefect_snowflake/credentials.py
@@ -85,7 +85,7 @@ class SnowflakeCredentials(CredentialsBlock):
     password: Optional[SecretStr] = Field(
         default=None, description="The password used to authenticate."
     )
-    private_key: Optional[SecretBytes] = Field(
+    private_key: Optional[SecretStr] = Field(
         default=None, description="The PEM used to authenticate."
     )
     private_key_path: Optional[Path] = Field(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -112,6 +112,7 @@ def private_key_no_pass_credentials_params():
         "private_key": _read_test_file("test_cert_no_pass.p8"),
     }
 
+
 @pytest.fixture()
 def private_no_pass_connector_params(private_no_pass_credentials_params):
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -105,6 +105,14 @@ def private_no_pass_credentials_params():
 
 
 @pytest.fixture()
+def private_key_no_pass_credentials_params():
+    return {
+        "account": "account",
+        "user": "user",
+        "private_key": _read_test_file("test_cert_no_pass.p8"),
+    }
+
+@pytest.fixture()
 def private_no_pass_connector_params(private_no_pass_credentials_params):
 
     snowflake_credentials = SnowflakeCredentials(**private_no_pass_credentials_params)

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -219,13 +219,21 @@ def test_snowflake_credentials_validate_private_key_is_pem(
         assert credentials.resolve_private_key() is not None
 
 
-def test_snowflake_credentials_validate_private_key_is_pem_bytes(
+def test_snowflake_credentials_validate_invalid_private_key_is_not_pem_bytes(
     private_no_pass_credentials_params,
 ):
     private_no_pass_credentials_params["private_key"] = "_invalid_key_"
     with pytest.raises(InvalidPemFormat):
         credentials = SnowflakeCredentials(**private_no_pass_credentials_params)
         assert credentials.resolve_private_key() is not None
+
+
+def test_snowflake_credentials_validate_private_key_is_pem_bytes(
+    private_key_no_pass_credentials_params,
+):
+    credentials = SnowflakeCredentials(**private_key_no_pass_credentials_params)
+    resolved_key = credentials.resolve_private_key()
+    assert resolved_key is not None
 
 
 def test_snowflake_credentials_validate_private_key_path_init(


### PR DESCRIPTION
* When you attempt to run a DbtCoreOperation on a DbtCliProfile that incorporates Snowflake key-pair credentials: private key and passphrase, you'll receive a Runtime Error like below,

Runtime Error
  in _deep_map_render, expected one of (<class 'list'>, <class 'dict'>, <class 'int'>, <class 'float'>, <class 'str'>, <class 'NoneType'>, <class 'bool'>, <class 'datetime.date'>), got <class 'bytes'>

  due to the expectation of a supported type associated with the profile's attribute values, which does not include bytes.

  Converting the Pydantic Secret type for the private key from bytes to string - SecretBytes to SecretStr - solves this issue.

<!-- Thanks for contributing 🎉! Please ensure the title neatly summarizes the proposed changes. -->

<!-- Overview -->

Closes

### Example
<!-- A code blurb is best. Changes to features should include an example that is executable by a new user. -->

### Screenshots
<!--
Any relevant screenshots
  - The updated docs page from `mkdocs serve`.
  - Output from running the example.
  - Service integration test results.
-->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [X] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-snowflake/issues/new/choose) first.
- [X] Includes tests or only affects documentation.
- [X] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [X] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
- [X] Summarizes PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-snowflake/blob/main/CHANGELOG.md)
