### PR TITLE
Fix `SnowflakeConnector block` loading example in UI

### DIFF
--- a/prefect_snowflake/database.py
+++ b/prefect_snowflake/database.py
@@ -52,7 +52,7 @@ class SnowflakeConnector(DatabaseBlock):
         ```python
         from prefect_snowflake.database import SnowflakeConnector
 
-        snowflake_connector = SnowflakeConnector.load("BLOCK_NAME"):
+        snowflake_connector = SnowflakeConnector.load("BLOCK_NAME")
         ```
 
         Insert data into database and fetch results.


### PR DESCRIPTION
After creating a SnowflakeConnector block, the code snippet we provide in the UI has a trailing colon that leads to failure if copied verbatim. This PR removes the colon.

Screenshot:
![Screenshot 2024-04-25 at 3 32 43 PM](https://github.com/PrefectHQ/prefect-snowflake/assets/7703961/711a599d-2e69-41a9-8ca3-7e52530e912c)

Closes

### Example
<!-- A code blurb is best. Changes to features should include an example that is executable by a new user. -->

### Screenshots
<!--
Any relevant screenshots
  - The updated docs page from `mkdocs serve`.
  - Output from running the example.
  - Service integration test results.
-->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-snowflake/issues/new/choose) first.
- [X] Includes tests or only affects documentation.
- [ ] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [X] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
